### PR TITLE
use channels in API

### DIFF
--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -75,7 +75,7 @@ func main() {
 		if options.Feed.Format == "" {
 			options.Feed.Format = "csv"
 		}
-		err = gotie.GetPeriodFeeds(options.Feed.Period,
+		err = gotie.PrintPeriodFeeds(options.Feed.Period,
 			strings.ToLower(options.Feed.DataType), options.Feed.Format)
 		if err != nil {
 			log.Fatal(err)

--- a/v1/structs.go
+++ b/v1/structs.go
@@ -44,6 +44,11 @@ type IOC struct {
 	ObservationAttributes []string   `json:"observation_attributes"`
 }
 
+type IOCResult struct {
+	IOC      *IOC
+	Error    *error
+}
+
 // IOCParams contains all necessary query parameters
 type IOCParams struct {
 	NoDefaults       bool       `json:"no_defaults"`


### PR DESCRIPTION
This PR proposes an extension to the IOC API that allows the use of channels to deliver IOCs in a consistent fashion from feeds and queries. Wrappers are provided to mimic the previous behaviour returning `*IOCQueryStruct`s. Also, I have pushed a cleaner separation between `Get*()` functions (returning values) and `Print*()` functions (outputting to stdout).