### PR TITLE
Various extensions and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 # Change Log
 
-## v0.1.0 (2017-01-30)
+## v0.1.1 (2017-01-30)
 
 **Implemented enhancements**
 
-- Added changelog, prepared first versioned release
+- Added JSON input channel delivering IOCs from JSON code parsed from an `io.Reader`
+- Simplified option parsing.
+- Addition of new query parameters to the `iocs` and `feeds` subcommands.
+- JSON results are now aggregated in one IOC array across API pages.
+- New `WriteIOCs()` and `WritePeriodFeeds()` APIfunctions accepting an `io.Reader`as output.
+- Rewording of error messages.
+
+**Bugs fixed**
+
+- Link header parsing would faild due to bug in previously used library regarding commas in URLs. Fixed by switching to different implementation.
+
+**Changes**
+
+- IOCResult struct field `Error` is no longer a pointer to an error value.
+
+## v0.1.0 (2016-11-29)
+
+- Initial open source release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## v0.1.0 (2017-01-30)
+
+**Implemented enhancements**
+
+- Added changelog, prepared first versioned release

--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -5,12 +5,12 @@ package main
 
 import (
 	"log"
+	"net/url"
 	"os"
-	"regexp"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
-	"net/url"
 
 	"github.com/voxelbrain/goptions"
 
@@ -18,35 +18,35 @@ import (
 )
 
 type IOCSParams struct {
-	Query             string `goptions:"-q,--query, description='Query string (case insensitive)', obligatory"`
-	Format            string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
-	DataType          string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`
-	Severity          string `goptions:"--severity, description='Specify severity (can be a range)'"`
-	Confidence        string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
-	Updated_since     string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
-	Updated_until     string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
-	Created_since     string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
-	Created_until     string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
-	First_seen_since  string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
-	First_seen_until  string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
-	Last_seen_since   string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
-	Last_seen_until   string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
+	Query            string `goptions:"-q,--query, description='Query string (case insensitive)', obligatory"`
+	Format           string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
+	DataType         string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`
+	Severity         string `goptions:"--severity, description='Specify severity (can be a range)'"`
+	Confidence       string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
+	Updated_since    string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
+	Updated_until    string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
+	Created_since    string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
+	Created_until    string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
+	First_seen_since string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
+	First_seen_until string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
+	Last_seen_since  string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
+	Last_seen_until  string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
 }
 
 type FeedParams struct {
-	Period   string `goptions:"-p,--period, description='Get TIE feed for given period (hourly|daily|weekly|monthly)', obligatory"`
-	Format   string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
-	DataType string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
-	Severity          string `goptions:"--severity, description='Specify severity (can be a range)'"`
-	Confidence        string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
-	Updated_since     string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
-	Updated_until     string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
-	Created_since     string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
-	Created_until     string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
-	First_seen_since  string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
-	First_seen_until  string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
-	Last_seen_since   string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
-	Last_seen_until   string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
+	Period           string `goptions:"-p,--period, description='Get TIE feed for given period (hourly|daily|weekly|monthly)', obligatory"`
+	Format           string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
+	DataType         string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
+	Severity         string `goptions:"--severity, description='Specify severity (can be a range)'"`
+	Confidence       string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
+	Updated_since    string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
+	Updated_until    string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
+	Created_since    string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
+	Created_until    string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
+	First_seen_since string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
+	First_seen_until string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
+	Last_seen_since  string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
+	Last_seen_until  string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
 }
 
 type PingBackParams struct {
@@ -54,26 +54,26 @@ type PingBackParams struct {
 	Value    string `goptions:"-v,--value, description='Specify a valid TIE IOC data value', obligatory"`
 }
 
-type Params interface {}
+type Params interface{}
 
 func parseTime(timeString string) (time.Time, error) {
 	var mtime time.Time
 	var err error
 
 	formats := []string{"2006-01-02",
-						"2006-01-02 15:04",
-						"2006/01/02",
-						"2006/01/02 15:04",
-						time.ANSIC,
-						time.UnixDate,
-						time.RubyDate,
-						time.RFC822,
-						time.RFC822Z,
-						time.RFC850,
-						time.RFC1123,
-						time.RFC1123Z,
-						time.RFC3339,
-						time.RFC3339Nano}
+		"2006-01-02 15:04",
+		"2006/01/02",
+		"2006/01/02 15:04",
+		time.ANSIC,
+		time.UnixDate,
+		time.RubyDate,
+		time.RFC822,
+		time.RFC822Z,
+		time.RFC850,
+		time.RFC1123,
+		time.RFC1123Z,
+		time.RFC3339,
+		time.RFC3339Nano}
 
 	for _, format := range formats {
 		mtime, err = time.Parse(format, timeString)
@@ -86,25 +86,25 @@ func parseTime(timeString string) (time.Time, error) {
 }
 
 func buildArgs(params Params, typestr string) string {
-	sharedParams := map[string]bool {
-		"Severity":true,
-		"Confidence":true,
-		"Updated_since":true,
-		"Updated_until":true,
-		"Created_since":true,
-		"Created_until":true,
-		"First_seen_since":true,
-		"First_seen_until":true,
-		"Last_seen_since":true,
-		"Last_seen_until":true,
+	sharedParams := map[string]bool{
+		"Severity":         true,
+		"Confidence":       true,
+		"Updated_since":    true,
+		"Updated_until":    true,
+		"Created_since":    true,
+		"Created_until":    true,
+		"First_seen_since": true,
+		"First_seen_until": true,
+		"Last_seen_since":  true,
+		"Last_seen_until":  true,
 	}
 	var p reflect.Value
 
 	if typestr == "iocs" {
-		iocparams :=  params.(IOCSParams)
+		iocparams := params.(IOCSParams)
 		p = reflect.ValueOf(&iocparams).Elem()
 	} else if typestr == "feed" {
-		feedparams :=  params.(FeedParams)
+		feedparams := params.(FeedParams)
 		p = reflect.ValueOf(&feedparams).Elem()
 	}
 	values := []string{""}
@@ -123,7 +123,7 @@ func buildArgs(params Params, typestr string) string {
 				}
 				outval = timeval.Format("2006-01-02T15:04:05Z")
 			}
-			argPair := url.QueryEscape(strings.ToLower(field_name)) + "="+ url.QueryEscape(outval)
+			argPair := url.QueryEscape(strings.ToLower(field_name)) + "=" + url.QueryEscape(outval)
 			values = append(values, argPair)
 		}
 	}
@@ -146,7 +146,7 @@ func main() {
 	options := Options{
 		ConfPath: getDefaultConfPath(),
 		IOCS: IOCSParams{
-			Format: "csv",
+			Format:           "csv",
 			First_seen_since: "2015-01-01",
 		},
 		Feed: FeedParams{

--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -6,44 +6,157 @@ package main
 import (
 	"log"
 	"os"
+	"regexp"
+	"reflect"
 	"strings"
+	"time"
+	"net/url"
 
 	"github.com/voxelbrain/goptions"
 
 	"github.com/DCSO/gotie/v1"
 )
 
+type IOCSParams struct {
+	Query             string `goptions:"-q,--query, description='Query string (case insensitive)', obligatory"`
+	Format            string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
+	DataType          string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`
+	Severity          string `goptions:"--severity, description='Specify severity (can be a range)'"`
+	Confidence        string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
+	Updated_since     string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
+	Updated_until     string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
+	Created_since     string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
+	Created_until     string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
+	First_seen_since  string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
+	First_seen_until  string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
+	Last_seen_since   string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
+	Last_seen_until   string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
+}
+
+type FeedParams struct {
+	Period   string `goptions:"-p,--period, description='Get TIE feed for given period (hourly|daily|weekly|monthly)', obligatory"`
+	Format   string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
+	DataType string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
+	Severity          string `goptions:"--severity, description='Specify severity (can be a range)'"`
+	Confidence        string `goptions:"--confidence, description='Specify confidence (can be a range)'"`
+	Updated_since     string `goptions:"--updated-since, description='Limit to IOCs updated since the given date'"`
+	Updated_until     string `goptions:"--updated-until, description='Limit to IOCs updated until the given date'"`
+	Created_since     string `goptions:"--created-since, description='Limit to IOCs created since the given date'"`
+	Created_until     string `goptions:"--created-until, description='Limit to IOCs created until the given date'"`
+	First_seen_since  string `goptions:"--first-seen-since, description='Limit to IOCs first seen since the given date'"`
+	First_seen_until  string `goptions:"--first-seen-until, description='Limit to IOCs first seen until the given date'"`
+	Last_seen_since   string `goptions:"--last-seen-since, description='Limit to IOCs last seen since the given date'"`
+	Last_seen_until   string `goptions:"--last-seen-until, description='Limit to IOCs last seen until the given date'"`
+}
+
+type PingBackParams struct {
+	DataType string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
+	Value    string `goptions:"-v,--value, description='Specify a valid TIE IOC data value', obligatory"`
+}
+
+type Params interface {}
+
+func parseTime(timeString string) (time.Time, error) {
+	var mtime time.Time
+	var err error
+
+	formats := []string{"2006-01-02",
+						"2006-01-02 15:04",
+						"2006/01/02",
+						"2006/01/02 15:04",
+						time.ANSIC,
+						time.UnixDate,
+						time.RubyDate,
+						time.RFC822,
+						time.RFC822Z,
+						time.RFC850,
+						time.RFC1123,
+						time.RFC1123Z,
+						time.RFC3339,
+						time.RFC3339Nano}
+
+	for _, format := range formats {
+		mtime, err = time.Parse(format, timeString)
+		if err == nil {
+			return mtime, err
+		}
+	}
+
+	return mtime, err
+}
+
+func buildArgs(params Params, typestr string) string {
+	sharedParams := map[string]bool {
+		"Severity":true,
+		"Confidence":true,
+		"Updated_since":true,
+		"Updated_until":true,
+		"Created_since":true,
+		"Created_until":true,
+		"First_seen_since":true,
+		"First_seen_until":true,
+		"Last_seen_since":true,
+		"Last_seen_until":true,
+	}
+	var p reflect.Value
+
+	if typestr == "iocs" {
+		iocparams :=  params.(IOCSParams)
+		p = reflect.ValueOf(&iocparams).Elem()
+	} else if typestr == "feed" {
+		feedparams :=  params.(FeedParams)
+		p = reflect.ValueOf(&feedparams).Elem()
+	}
+	values := []string{""}
+	for i := 0; i < p.NumField(); i++ {
+		field_name := p.Type().Field(i).Name
+		field_value := p.Field(i).Interface().(string)
+		if sharedParams[field_name] && field_value != "" {
+			var err error
+			outval := field_value
+			matched, _ := regexp.MatchString("_(since|until)$", field_name)
+			if matched {
+				var timeval time.Time
+				timeval, err = parseTime(field_value)
+				if err != nil {
+					log.Fatal(err)
+				}
+				outval = timeval.Format("2006-01-02T15:04:05Z")
+			}
+			argPair := url.QueryEscape(strings.ToLower(field_name)) + "="+ url.QueryEscape(outval)
+			values = append(values, argPair)
+		}
+	}
+	return strings.Join(values, "&")
+}
+
+type Options struct {
+	ConfPath string        `goptions:"-c,--conf,description='Set non default config path'"`
+	Debug    bool          `goptions:"-d,--debug,description='Print debug messages'"`
+	Help     goptions.Help `goptions:"-h, --help, description='Show this help'"`
+
+	goptions.Verbs
+	IOCS     IOCSParams     `goptions:"iocs"`
+	Feed     FeedParams     `goptions:"feed"`
+	PingBack PingBackParams `goptions:"pingback"`
+}
+
 func main() {
 	var err error
-	options := struct {
-		ConfPath string        `goptions:"-c,--conf,description='Set non default config path'"`
-		Debug    bool          `goptions:"-d,--debug,description='Print debug messages'"`
-		Help     goptions.Help `goptions:"-h, --help, description='Show this help'"`
-
-		goptions.Verbs
-		IOCS struct {
-			Query    string `goptions:"-q,--query, description='Query string (case insensitive)', obligatory"`
-			Format   string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
-			DataType string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`
-		} `goptions:"iocs"`
-		Feed struct {
-			Period   string `goptions:"-p,--period, description='Get TIE feed for given period (hourly|daily|weekly|monthly)', obligatory"`
-			Format   string `goptions:"-f,--format, description='Specify output format (csv)'"`
-			DataType string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
-		} `goptions:"feed"`
-		PingBack struct {
-			DataType string `goptions:"-t,--type, description='Specify a valid TIE IOC data type', obligatory"`
-			Value    string `goptions:"-v,--value, description='Specify a valid TIE IOC data value', obligatory"`
-		} `goptions:"pingback"`
-	}{ // Default values goes here
+	options := Options{
 		ConfPath: getDefaultConfPath(),
+		IOCS: IOCSParams{
+			Format: "csv",
+			First_seen_since: "2015-01-01",
+		},
+		Feed: FeedParams{
+			Format: "csv",
+		},
 	}
 	goptions.ParseAndFail(&options)
 
 	// If the user does not select any Verb we print the help and exit
-	if options.IOCS.Query == "" &&
-		options.Feed.Period == "" &&
-		options.PingBack.DataType == "" {
+	if options.Verbs == "" {
 		goptions.PrintHelp()
 		os.Exit(1)
 	}
@@ -60,36 +173,33 @@ func main() {
 	}
 	gotie.AuthToken = CONF.TieToken
 
-	if options.IOCS.Query != "" {
-		if options.IOCS.Format == "" {
-			options.IOCS.Format = "csv"
-		}
+	if options.Verbs == "iocs" {
 		err = gotie.PrintIOCs(options.IOCS.Query, options.IOCS.DataType,
-			"&first_seen_since=2015-1-1", options.IOCS.Format)
+			buildArgs(options.IOCS, "iocs"), options.IOCS.Format)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	if options.Feed.Period != "" {
-		if options.Feed.Format == "" {
-			options.Feed.Format = "csv"
-		}
+	if options.Verbs == "feed" {
 		err = gotie.PrintPeriodFeeds(options.Feed.Period,
-			strings.ToLower(options.Feed.DataType), options.Feed.Format)
+			strings.ToLower(options.Feed.DataType),
+			buildArgs(options.IOCS, "iocs"), options.Feed.Format)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	if options.PingBack.DataType != "" && options.PingBack.Value != "" {
-		if CONF.PingBackToken == "" {
-			log.Fatal("Please set a valid pingback_token in your config file!")
-		}
-		err = gotie.PingBackCall(options.PingBack.DataType, options.PingBack.Value,
-			CONF.PingBackToken)
-		if err != nil {
-			log.Fatal(err)
+	if options.Verbs == "pingback" {
+		if options.PingBack.DataType != "" && options.PingBack.Value != "" {
+			if CONF.PingBackToken == "" {
+				log.Fatal("Please set a valid pingback_token in your config file!")
+			}
+			err = gotie.PingBackCall(options.PingBack.DataType, options.PingBack.Value,
+				CONF.PingBackToken)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -136,6 +136,27 @@ func GetIOCPeriodFeedChan(feedPeriod string, dataType string, extraArgs string) 
 	return outchan
 }
 
+func GetIOCJSONInChan(reader io.Reader) (<-chan IOCResult, error) {
+	var iocs struct {
+		IOCs []IOC
+	}
+	outchan := make(chan IOCResult)
+
+	err := json.NewDecoder(reader).Decode(&iocs)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for i, _ := range iocs.IOCs  {
+			outchan <- IOCResult{IOC: &iocs.IOCs[i], Error: nil}
+		}
+		close(outchan)
+	}()
+
+	return outchan, nil
+}
+
 func IOCChanCollect(inchan <-chan IOCResult) (*IOCQueryStruct, error) {
 	var outData IOCQueryStruct
 

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -78,7 +78,7 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 			}
 			errStr := fmt.Sprintf("TIE returned an error: %v %v", msg.Message, msg.Errors)
 			this_err := errors.New(errStr)
-			outchan <- IOCResult{IOC:nil, Error: &this_err}
+			outchan <- IOCResult{IOC: nil, Error: &this_err}
 			close(outchan)
 			return
 		}
@@ -105,31 +105,31 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 	close(outchan)
 }
 
-func GetIOCChan(query string, dataType string, extraArgs string) (<-chan IOCResult) {
+func GetIOCChan(query string, dataType string, extraArgs string) <-chan IOCResult {
 	data := IOCQueryStruct{HasMore: true}
 	outchan := make(chan IOCResult)
 
-    uri := apiURL +
-			"iocs?data_type=" + strings.ToLower(dataType) +
-			"&ivalue=" + query +
-			"&limit=" + strconv.Itoa(IOCLimit) +
-			"&date_format=rfc3339" +
-			extraArgs
+	uri := apiURL +
+		"iocs?data_type=" + strings.ToLower(dataType) +
+		"&ivalue=" + query +
+		"&limit=" + strconv.Itoa(IOCLimit) +
+		"&date_format=rfc3339" +
+		extraArgs
 
 	go IOCQuery(uri, outchan, data)
 
 	return outchan
 }
 
-func GetIOCPeriodFeedChan(feedPeriod string, dataType string, extraArgs string) (<-chan IOCResult) {
+func GetIOCPeriodFeedChan(feedPeriod string, dataType string, extraArgs string) <-chan IOCResult {
 	data := IOCQueryStruct{HasMore: true}
 	outchan := make(chan IOCResult)
 
-    uri := apiURL +
-			"iocs/feed/"+ feedPeriod + "?data_type=" + strings.ToLower(dataType) +
-			"&limit=" + strconv.Itoa(IOCLimit) +
-			"&date_format=rfc3339" +
-			extraArgs
+	uri := apiURL +
+		"iocs/feed/" + feedPeriod + "?data_type=" + strings.ToLower(dataType) +
+		"&limit=" + strconv.Itoa(IOCLimit) +
+		"&date_format=rfc3339" +
+		extraArgs
 
 	go IOCQuery(uri, outchan, data)
 
@@ -148,7 +148,7 @@ func GetIOCJSONInChan(reader io.Reader) (<-chan IOCResult, error) {
 	}
 
 	go func() {
-		for i, _ := range iocs.IOCs  {
+		for i, _ := range iocs.IOCs {
 			outchan <- IOCResult{IOC: &iocs.IOCs[i], Error: nil}
 		}
 		close(outchan)
@@ -190,17 +190,17 @@ func WriteIOCs(query string, dataType string, extraArgs string, outputFormat str
 	var agg PageContentAggregator
 
 	switch outputFormat {
-		case "csv":
-			acceptHdr = "text/csv"
-			agg = &PaginatedRawPageAggregator{}
-		case "json":
-			acceptHdr = "application/json"
-			agg = &JSONPageAggregator{}
-		case "stix":
-			acceptHdr = "text/xml"
-			agg = &PaginatedRawPageAggregator{}
-		default:
-			return errors.New("Unsupported output format requested: " + outputFormat)
+	case "csv":
+		acceptHdr = "text/csv"
+		agg = &PaginatedRawPageAggregator{}
+	case "json":
+		acceptHdr = "application/json"
+		agg = &JSONPageAggregator{}
+	case "stix":
+		acceptHdr = "text/xml"
+		agg = &PaginatedRawPageAggregator{}
+	default:
+		return errors.New("Unsupported output format requested: " + outputFormat)
 	}
 
 	// The TIE API uses a paging mechanism to return all matched IOCs. So we have
@@ -277,10 +277,10 @@ func WritePeriodFeeds(feedPeriod string, dataType string, extraArgs string, outp
 	var msg apiMessage
 
 	req, err := http.NewRequest("GET",
-		apiURL + "iocs/feed/"+feedPeriod+"/"+strings.ToLower(dataType) +
-		         "?limit=" + strconv.Itoa(IOCLimit) +
-		         "&date_format=rfc3339" +
-		         extraArgs,
+		apiURL+"iocs/feed/"+feedPeriod+"/"+strings.ToLower(dataType)+
+			"?limit="+strconv.Itoa(IOCLimit)+
+			"&date_format=rfc3339"+
+			extraArgs,
 		nil)
 	if err != nil {
 		return err

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -217,7 +217,7 @@ func PrintIOCs(query string, dataType string, extraArgs string, outputFormat str
 		case "stix":
 			req.Header.Add("Accept", "text/xml")
 		default:
-			return errors.New("Not supported output format requested: " + outputFormat)
+			return errors.New("Unsupported output format requested: " + outputFormat)
 		}
 
 		req.Header.Add("Authorization", "Bearer "+AuthToken)
@@ -278,7 +278,7 @@ func PrintPeriodFeeds(feedPeriod string, dataType string, extraArgs string, outp
 	case "stix":
 		req.Header.Add("Accept", "text/xml")
 	default:
-		return errors.New("Not supported output format requested: " + outputFormat)
+		return errors.New("Unsupported output format requested: " + outputFormat)
 	}
 
 	req.Header.Add("Authorization", "Bearer "+AuthToken)

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -257,11 +257,14 @@ func PrintIOCs(query string, dataType string, extraArgs string, outputFormat str
 
 // GetPeriodFeeds gets file based feeds for the given period and IOC data type.
 // Valid outputFormats are: "csv" (default), "json" and "stix" and print to stdout
-func PrintPeriodFeeds(feedPeriod string, dataType string, outputFormat string) error {
+func PrintPeriodFeeds(feedPeriod string, dataType string, extraArgs string, outputFormat string) error {
 	var msg apiMessage
 
 	req, err := http.NewRequest("GET",
-		apiURL+"iocs/feed/"+feedPeriod+"/"+strings.ToLower(dataType)+"?limit="+strconv.Itoa(IOCLimit),
+		apiURL + "iocs/feed/"+feedPeriod+"/"+strings.ToLower(dataType) +
+		         "?limit=" + strconv.Itoa(IOCLimit) +
+		         "&date_format=rfc3339" +
+		         extraArgs,
 		nil)
 	if err != nil {
 		return err

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -50,7 +50,7 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 
 		req, err := http.NewRequest("GET", uri, nil)
 		if err != nil {
-			outchan <- IOCResult{IOC: nil, Error: &err}
+			outchan <- IOCResult{IOC: nil, Error: err}
 			break
 		}
 		req.Header.Add("Accept", "application/json")
@@ -58,7 +58,7 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			outchan <- IOCResult{IOC: nil, Error: &err}
+			outchan <- IOCResult{IOC: nil, Error: err}
 			close(outchan)
 			return
 		}
@@ -72,26 +72,26 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 		if resp.StatusCode != 200 {
 			err = json.NewDecoder(resp.Body).Decode(&msg)
 			if err != nil {
-				outchan <- IOCResult{IOC: nil, Error: &err}
+				outchan <- IOCResult{IOC: nil, Error: err}
 				close(outchan)
 				return
 			}
 			errStr := fmt.Sprintf("TIE returned an error: %v %v", msg.Message, msg.Errors)
 			this_err := errors.New(errStr)
-			outchan <- IOCResult{IOC: nil, Error: &this_err}
+			outchan <- IOCResult{IOC: nil, Error: this_err}
 			close(outchan)
 			return
 		}
 
 		err = json.NewDecoder(resp.Body).Decode(&data)
 		if err != nil {
-			outchan <- IOCResult{IOC: nil, Error: &err}
+			outchan <- IOCResult{IOC: nil, Error: err}
 			close(outchan)
 			return
 		}
 		_, err = json.Marshal(data.Iocs)
 		if err != nil {
-			outchan <- IOCResult{IOC: nil, Error: &err}
+			outchan <- IOCResult{IOC: nil, Error: err}
 			close(outchan)
 			return
 		}
@@ -162,7 +162,7 @@ func IOCChanCollect(inchan <-chan IOCResult) (*IOCQueryStruct, error) {
 
 	for ioc := range inchan {
 		if ioc.Error != nil {
-			return &outData, *(ioc.Error)
+			return &outData, ioc.Error
 		}
 		outData.Iocs = append(outData.Iocs, *(ioc.IOC))
 	}

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -182,9 +182,7 @@ func GetIOCPeriodFeeds(feedPeriod string, dataType string, extraArgs string) (*I
 	return IOCChanCollect(GetIOCPeriodFeedChan(feedPeriod, dataType, extraArgs))
 }
 
-// PrintIOCs allows queries for TIE IOC objects with "query" beeing a case
-// insensitive string to search for. The results are printed to stdout.
-func PrintIOCs(query string, dataType string, extraArgs string, outputFormat string) error {
+func WriteIOCs(query string, dataType string, extraArgs string, outputFormat string, dest io.Writer) error {
 	var uri string
 	var acceptHdr string
 	var offset int
@@ -271,13 +269,11 @@ func PrintIOCs(query string, dataType string, extraArgs string, outputFormat str
 		offset += IOCLimit
 	}
 
-	agg.Finish(os.Stdout)
+	agg.Finish(dest)
 	return nil
 }
 
-// GetPeriodFeeds gets file based feeds for the given period and IOC data type.
-// Valid outputFormats are: "csv" (default), "json" and "stix" and print to stdout
-func PrintPeriodFeeds(feedPeriod string, dataType string, extraArgs string, outputFormat string) error {
+func WritePeriodFeeds(feedPeriod string, dataType string, extraArgs string, outputFormat string, dest io.Writer) error {
 	var msg apiMessage
 
 	req, err := http.NewRequest("GET",
@@ -324,12 +320,24 @@ func PrintPeriodFeeds(feedPeriod string, dataType string, extraArgs string, outp
 		return errors.New(errStr)
 	}
 
-	_, err = io.Copy(os.Stdout, resp.Body)
+	_, err = io.Copy(dest, resp.Body)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// PrintIOCs allows queries for TIE IOC objects with "query" being a case
+// insensitive string to search for. The results are printed to stdout.
+func PrintIOCs(query string, dataType string, extraArgs string, outputFormat string) error {
+	return WriteIOCs(query, dataType, extraArgs, outputFormat, os.Stdout)
+}
+
+// PrintPeriodFeeds gets file based feeds for the given period and IOC data type.
+// Valid outputFormats are: "csv" (default), "json" and "stix". Results are printed to stdout.
+func PrintPeriodFeeds(feedPeriod string, dataType string, extraArgs string, outputFormat string) error {
+	return WritePeriodFeeds(feedPeriod, dataType, extraArgs, outputFormat, os.Stdout)
 }
 
 // PingBackCall allows to tell the TIE about observed hits for IOCs

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/peterhellberg/link"
+	"github.com/tent/http-link-go"
 )
 
 var (
@@ -245,8 +245,20 @@ func PrintIOCs(query string, dataType string, extraArgs string, outputFormat str
 		// Due to the various output types we can not marshal and check the HasMore
 		// header here. Fortunately TIE also returns a Link header for pagination.
 		// Ref: https://tie.dcso.de/api-docs/api/v1/pagination.html
-		group := link.ParseResponse(resp)
-		if group["next"] == nil {
+		var links []link.Link
+		found_next := false
+		if resp.Header.Get("Link") != "" {
+			links, err = link.Parse(resp.Header.Get("Link"))
+			if err != nil {
+				return err
+			}
+			for _, l := range links {
+				if l.Rel == "next" {
+					found_next = true
+				}
+			}
+		}
+		if !found_next {
 			break
 		}
 

--- a/v1/functions_test.go
+++ b/v1/functions_test.go
@@ -59,11 +59,11 @@ func TestGetIocs(t *testing.T) {
 	feedchan = GetIOCPeriodFeedChan("foobar", "DomainName", "")
 	_, err = IOCChanCollect(feedchan)
 	if err == nil {
-		t.Logf("ERROR: expected failure for invalid keyword", err)
+		t.Log("ERROR: expected failure for invalid keyword", err)
 		t.FailNow()
 	} else {
 		if !strings.Contains(fmt.Sprintf("%s", err), "invalid period") {
-			t.Logf("ERROR: expected invalid period error message", err)
+			t.Log("ERROR: expected invalid period error message", err)
 			t.FailNow()
 		}
 	}

--- a/v1/functions_test.go
+++ b/v1/functions_test.go
@@ -55,8 +55,8 @@ func TestGetIocs(t *testing.T) {
 		t.FailNow()
 	}
 
-    feedchan = GetIOCPeriodFeedChan("foobar", "DomainName", "")
-    _, err = IOCChanCollect(feedchan)
+	feedchan = GetIOCPeriodFeedChan("foobar", "DomainName", "")
+	_, err = IOCChanCollect(feedchan)
 	if err == nil {
 		t.Logf("ERROR: expected failure for invalid keyword", err)
 		t.FailNow()

--- a/v1/functions_test.go
+++ b/v1/functions_test.go
@@ -85,7 +85,7 @@ func TestGetIocs(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = PrintPeriodFeeds("daily", "DomainName", "csv")
+	err = PrintPeriodFeeds("daily", "DomainName", "", "csv")
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()

--- a/v1/functions_test.go
+++ b/v1/functions_test.go
@@ -124,7 +124,6 @@ func TestWriteIocs(t *testing.T) {
 
 func TestReadWriteIocsJSON(t *testing.T) {
 	var err error
-	var readfile *os.File
 	var jsonchan <-chan IOCResult
 	var res *IOCQueryStruct
 
@@ -140,19 +139,13 @@ func TestReadWriteIocsJSON(t *testing.T) {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}
-	if err := tmpfile.Close(); err != nil {
+	tmpfile.Sync()
+	_, err = tmpfile.Seek(0, 0)
+	if  err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}
-
-	readfile, err = os.Open(tmpfile.Name())
-	if err != nil {
-		t.Logf("ERROR: %v", err)
-		t.FailNow()
-	}
-	defer readfile.Close()
-
-	jsonchan, err = GetIOCJSONInChan(readfile)
+	jsonchan, err = GetIOCJSONInChan(tmpfile)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -4,9 +4,9 @@ package gotie
 // Copyright (c) 2017, DCSO GmbH
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
-	"bytes"
 )
 
 type PageContentAggregator interface {
@@ -34,14 +34,14 @@ func (pa *PaginatedRawPageAggregator) Reset() {
 }
 
 type JSONTopLevelResponse struct {
-	Params   IOCParams       `json:"params"`
-	IOCs     []IOC           `json:"iocs"`
-	has_more bool            `json:"has_more"`
+	Params   IOCParams `json:"params"`
+	IOCs     []IOC     `json:"iocs"`
+	has_more bool      `json:"has_more"`
 }
 
 type JSONPageAggregator struct {
-	IOCs   []IOC             `json:"iocs"`
-	Params IOCParams         `json:"params"`
+	IOCs   []IOC     `json:"iocs"`
+	Params IOCParams `json:"params"`
 }
 
 func (pa *JSONPageAggregator) AddPage(reader io.Reader) error {

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -1,0 +1,98 @@
+package gotie
+
+// DCSO gotie API bindings
+// Copyright (c) 2017, DCSO GmbH
+
+import (
+	"encoding/json"
+//	"encoding/xml"
+//	"errors"
+//	"fmt"
+	"io"
+	"bytes"
+//	"regexp"
+)
+
+type PageContentAggregator interface {
+	AddPage(io.Reader) error
+	Finish(io.Writer) error
+	Reset()
+}
+
+type PaginatedRawPageAggregator struct {
+	buf bytes.Buffer
+}
+
+func (pa *PaginatedRawPageAggregator) AddPage(reader io.Reader) error {
+	_, err := pa.buf.ReadFrom(reader)
+	return err
+}
+
+func (pa *PaginatedRawPageAggregator) Finish(writer io.Writer) error {
+	_, err := pa.buf.WriteTo(writer)
+	return err
+}
+
+func (pa *PaginatedRawPageAggregator) Reset() {
+	pa.buf.Reset()
+}
+
+type JSONTopLevelResponse struct {
+	Params   IOCParams       `json:"params"`
+	IOCs     []IOC           `json:"iocs"`
+	has_more bool            `json:"has_more"`
+}
+
+type JSONPageAggregator struct {
+	IOCs   []IOC             `json:"iocs"`
+	Params IOCParams         `json:"params"`
+}
+
+func (pa *JSONPageAggregator) AddPage(reader io.Reader) error {
+	var tlr JSONTopLevelResponse
+
+	err := json.NewDecoder(reader).Decode(&tlr)
+	if err != nil {
+		return err
+	}
+
+	pa.IOCs = append(pa.IOCs, tlr.IOCs...)
+	pa.Params = tlr.Params
+
+	return err
+}
+
+func (pa *JSONPageAggregator) Finish(writer io.Writer) error {
+	var tlr JSONTopLevelResponse
+
+	tlr.Params = pa.Params
+	tlr.IOCs = pa.IOCs
+	tlr.has_more = false
+
+	err := json.NewEncoder(writer).Encode(&tlr)
+	return err
+}
+
+func (pa *JSONPageAggregator) Reset() {
+	*pa = JSONPageAggregator{}
+
+}
+
+// to be implemented
+/*
+type STIXPageAggregator struct {
+	buf bytes.Buffer
+}
+
+func (pa *STIXPageAggregator) AddPage(reader io.Reader) error {
+	return nil
+}
+
+func (pa *STIXPageAggregator) Finish(writer io.Writer) error {
+	return nil
+}
+
+func (pa *STIXPageAggregator) Reset() {
+	pa.buf.Reset()
+}
+*/

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -5,12 +5,8 @@ package gotie
 
 import (
 	"encoding/json"
-//	"encoding/xml"
-//	"errors"
-//	"fmt"
 	"io"
 	"bytes"
-//	"regexp"
 )
 
 type PageContentAggregator interface {

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -68,6 +68,8 @@ func (pa *JSONPageAggregator) Finish(writer io.Writer) error {
 	tlr.Params = pa.Params
 	tlr.IOCs = pa.IOCs
 	tlr.has_more = false
+	tlr.Params.Offset = 0
+	tlr.Params.Limit = len(tlr.IOCs)
 
 	err := json.NewEncoder(writer).Encode(&tlr)
 	return err

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -36,7 +36,7 @@ func (pa *PaginatedRawPageAggregator) Reset() {
 type JSONTopLevelResponse struct {
 	Params   IOCParams `json:"params"`
 	IOCs     []IOC     `json:"iocs"`
-	has_more bool      `json:"has_more"`
+	has_more bool
 }
 
 type JSONPageAggregator struct {

--- a/v1/structs.go
+++ b/v1/structs.go
@@ -46,7 +46,7 @@ type IOC struct {
 
 type IOCResult struct {
 	IOC   *IOC
-	Error *error
+	Error error
 }
 
 // IOCParams contains all necessary query parameters

--- a/v1/structs.go
+++ b/v1/structs.go
@@ -45,8 +45,8 @@ type IOC struct {
 }
 
 type IOCResult struct {
-	IOC      *IOC
-	Error    *error
+	IOC   *IOC
+	Error *error
 }
 
 // IOCParams contains all necessary query parameters


### PR DESCRIPTION
This PR introduces the following:
  - JSON input channel delivering IOCs from JSON code parsed from an `io.Reader`
  - simplification of tool options
  - addition of new query parameters to `iocs` and `feeds` subcommands
  - switch to different Link header parser due to https://github.com/peterhellberg/link/issues/2
  - implement merging of paginated results for JSON output
  - adding `WriteIOCs()` and `WritePeriodFeeds()` accepting an `io.Reader`; the `PrintIOCs()` and `PrintPeriodFeeds()` functions remain available
  - slightly reworded error messages

Please review'n'merge.