### PR TITLE
improve TIE query granularity

### DIFF
--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 type IOCSParams struct {
-	Query            string `goptions:"-q,--query, description='Query string (case insensitive)', obligatory"`
+	Query            string `goptions:"-q,--query, description='Query string (case insensitive)'"`
 	Format           string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
 	Category         string `goptions:"-c,--category, description='specify comma-separated IOC categories'"`
 	DataType         string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`

--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -90,7 +90,7 @@ func parseTime(timeString string) (time.Time, error) {
 	return mtime, err
 }
 
-func buildArgs(params Params, typestr string) string {
+func buildArgs(params Params, typestr string, debug bool) string {
 	sharedParams := map[string]bool{
 		"Severity":         true,
 		"Confidence":       true,
@@ -132,7 +132,9 @@ func buildArgs(params Params, typestr string) string {
 			argPair := url.QueryEscape(strings.ToLower(field_name)) + "=" + url.QueryEscape(outval)
 			values = append(values, argPair)
 		} else {
-			log.Printf("unknown or empty parameter %s skipped\n", field_name)
+			if debug {
+				log.Printf("unknown or empty parameter %s skipped\n", field_name)
+			}
 		}
 	}
 	return strings.Join(values, "&")
@@ -192,10 +194,10 @@ func main() {
 			log.Fatal(err)
 		}
 		if gotie.Debug {
-			log.Println(buildArgs(options.IOCS, "iocs"))
+			log.Println(buildArgs(options.IOCS, "iocs", options.Debug))
 		}
 		err = gotie.PrintIOCs(options.IOCS.Query, options.IOCS.DataType,
-			buildArgs(options.IOCS, "iocs"), options.IOCS.Format)
+			buildArgs(options.IOCS, "iocs", options.Debug), options.IOCS.Format)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -211,7 +213,7 @@ func main() {
 		}
 		err = gotie.PrintPeriodFeeds(options.Feed.Period,
 			strings.ToLower(options.Feed.DataType),
-			buildArgs(options.IOCS, "iocs"), options.Feed.Format)
+			buildArgs(options.IOCS, "iocs", options.Debug), options.Feed.Format)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -45,7 +46,7 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 		uri := baseuri + "&offset=" + strconv.Itoa(offset)
 
 		if Debug {
-			fmt.Println("Asking API for more IOCs at offset", strconv.Itoa(offset), uri)
+			log.Println("Asking API for more IOCs at offset", strconv.Itoa(offset), uri)
 		}
 
 		req, err := http.NewRequest("GET", uri, nil)
@@ -66,7 +67,7 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 
 		if Debug {
 			dump, _ := httputil.DumpResponse(resp, true)
-			fmt.Println(string(dump))
+			log.Println(string(dump))
 		}
 
 		if resp.StatusCode != 200 {
@@ -215,7 +216,7 @@ func WriteIOCs(query string, dataType string, extraArgs string, outputFormat str
 			extraArgs
 
 		if Debug {
-			fmt.Println("Asking API for more IOCs at offset", strconv.Itoa(offset), uri)
+			log.Println("Asking API for more IOCs at offset", strconv.Itoa(offset), uri)
 		}
 
 		req, err := http.NewRequest("GET", uri, nil)
@@ -305,10 +306,10 @@ func WritePeriodFeeds(feedPeriod string, dataType string, extraArgs string, outp
 	defer resp.Body.Close()
 
 	if Debug {
-		fmt.Println("Tried URL:" + apiURL + "iocs/feed/" + feedPeriod + "/" + dataType)
+		log.Println("Tried URL:" + apiURL + "iocs/feed/" + feedPeriod + "/" + dataType)
 		dump, _ := httputil.DumpResponse(resp, true)
-		fmt.Println(string(dump))
-		fmt.Println("Requested outputFormat:", outputFormat)
+		log.Println(string(dump))
+		log.Println("Requested outputFormat:", outputFormat)
 	}
 
 	if resp.StatusCode != 200 {
@@ -363,8 +364,8 @@ func PingBackCall(dataType string, value string, token string) error {
 	defer resp.Body.Close()
 
 	if Debug {
-		fmt.Println("Tried URL:" + apiURL + "submit")
-		fmt.Println("Requested body data:", form.Encode())
+		log.Println("Tried URL:" + apiURL + "submit")
+		log.Println("Requested body data:", form.Encode())
 	}
 
 	dump, err := httputil.DumpResponse(resp, true)

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -95,8 +95,8 @@ func IOCQuery(baseuri string, outchan chan IOCResult, data IOCQueryStruct) {
 			close(outchan)
 			return
 		}
-		for _, ioc := range data.Iocs {
-			outchan <- IOCResult{IOC: &ioc, Error: nil}
+		for i := range data.Iocs {
+			outchan <- IOCResult{IOC: &data.Iocs[i], Error: nil}
 		}
 		outData.Params = data.Params
 		outData.HasMore = data.HasMore

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -25,7 +25,7 @@ var (
 	// Debug turns on verbose output
 	Debug bool
 	// IOCLimit defines the maximum number of IOCs to query per request
-	IOCLimit = 10000
+	IOCLimit = 1000
 	// AuthToken can be generated in the TIE webinterface and is used for authentication
 	AuthToken string
 


### PR DESCRIPTION
This PR improves control over query granularity by making the chunk size per API call configurable, while also lowering the default to 1k IOCs/chunk. This reduces strain on the TIE while still allowing to fetch large data sets via the API.

Moreover, some minor fixes and cleanups are included.