### PR TITLE
Basic bloom filter output

### DIFF
--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -20,7 +20,8 @@ import (
 
 type IOCSParams struct {
 	Query            string `goptions:"-q,--query, description='Query string (case insensitive)'"`
-	Format           string `goptions:"-f,--format, description='Specify output format (csv|json|stix)'"`
+	Format           string `goptions:"-f,--format, description='Specify output format (bloom|csv|json|stix)'"`
+	BloomP           string `goptions:"--bloom-p, description='Bloom output: false positive rate'"`
 	Category         string `goptions:"-c,--category, description='specify comma-separated IOC categories'"`
 	DataType         string `goptions:"-t,--type, description='TIE IOC data type to search exclusively'"`
 	Severity         string `goptions:"--severity, description='Specify severity (can be a range)'"`
@@ -157,6 +158,7 @@ func main() {
 		ConfPath: getDefaultConfPath(),
 		IOCS: IOCSParams{
 			Format:           "csv",
+			BloomP:           "0.001",
 			First_seen_since: "2015-01-01",
 			Limit:            "1000",
 		},
@@ -196,8 +198,15 @@ func main() {
 		if gotie.Debug {
 			log.Println(buildArgs(options.IOCS, "iocs", options.Debug))
 		}
+
+		bloomP, err := strconv.ParseFloat(options.IOCS.BloomP, 64)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		err = gotie.PrintIOCs(options.IOCS.Query, options.IOCS.DataType,
-			buildArgs(options.IOCS, "iocs", options.Debug), options.IOCS.Format)
+			buildArgs(options.IOCS, "iocs", options.Debug), options.IOCS.Format,
+			bloomP)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -189,13 +189,16 @@ func GetIOCPeriodFeeds(feedPeriod string, dataType string, extraArgs string) (*I
 	return IOCChanCollect(GetIOCPeriodFeedChan(feedPeriod, dataType, extraArgs))
 }
 
-func WriteIOCs(query string, dataType string, extraArgs string, outputFormat string, dest io.Writer) error {
+func WriteIOCs(query, dataType, extraArgs, outputFormat string, bloomP float64, dest io.Writer) error {
 	var uri string
 	var acceptHdr string
 	var offset int
 	var agg PageContentAggregator
 
 	switch outputFormat {
+	case "bloom":
+		acceptHdr = "application/json"
+		agg = NewBloomPageAggregator(bloomP)
 	case "csv":
 		acceptHdr = "text/csv"
 		agg = &PaginatedRawPageAggregator{}
@@ -370,8 +373,8 @@ func WritePeriodFeeds(feedPeriod string, dataType string, extraArgs string, outp
 
 // PrintIOCs allows queries for TIE IOC objects with "query" being a case
 // insensitive string to search for. The results are printed to stdout.
-func PrintIOCs(query string, dataType string, extraArgs string, outputFormat string) error {
-	return WriteIOCs(query, dataType, extraArgs, outputFormat, os.Stdout)
+func PrintIOCs(query, dataType, extraArgs, outputFormat string, bloomP float64) error {
+	return WriteIOCs(query, dataType, extraArgs, outputFormat, bloomP, os.Stdout)
 }
 
 // PrintPeriodFeeds gets file based feeds for the given period and IOC data type.

--- a/v1/functions_test.go
+++ b/v1/functions_test.go
@@ -68,19 +68,19 @@ func TestGetIocs(t *testing.T) {
 		}
 	}
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "csv", ioutil.Discard)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "csv", 0, ioutil.Discard)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", ioutil.Discard)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", 0, ioutil.Discard)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "stix", ioutil.Discard)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "stix", 0, ioutil.Discard)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
@@ -105,7 +105,7 @@ func TestWriteIocs(t *testing.T) {
 	}
 	defer os.Remove(tmpfile.Name())
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", tmpfile)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", 0, tmpfile)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
@@ -134,14 +134,14 @@ func TestReadWriteIocsJSON(t *testing.T) {
 	}
 	defer os.Remove(tmpfile.Name())
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", tmpfile)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", 0, tmpfile)
 	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}
 	tmpfile.Sync()
 	_, err = tmpfile.Seek(0, 0)
-	if  err != nil {
+	if err != nil {
 		t.Logf("ERROR: %v", err)
 		t.FailNow()
 	}

--- a/v1/paging.go
+++ b/v1/paging.go
@@ -7,6 +7,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log"
+
+	"github.com/DCSO/bloom"
 )
 
 type PageContentAggregator interface {
@@ -73,7 +76,58 @@ func (pa *JSONPageAggregator) Finish(writer io.Writer) error {
 
 func (pa *JSONPageAggregator) Reset() {
 	*pa = JSONPageAggregator{}
+}
 
+type BloomPageAggregator struct {
+	p      float64
+	values []string
+}
+
+func NewBloomPageAggregator(p float64) (ba *BloomPageAggregator) {
+	ba = &BloomPageAggregator{
+		p: p,
+	}
+	ba.initialize()
+
+	return
+}
+
+func (ba *BloomPageAggregator) initialize() {
+	ba.values = make([]string, 0, 1e6)
+}
+
+func (ba *BloomPageAggregator) AddPage(reader io.Reader) (err error) {
+	var tlr JSONTopLevelResponse
+
+	err = json.NewDecoder(reader).Decode(&tlr)
+	if err != nil {
+		return err
+	}
+
+	for _, ioc := range tlr.IOCs {
+		ba.values = append(ba.values, ioc.Value)
+	}
+
+	return nil
+}
+
+func (ba *BloomPageAggregator) Finish(writer io.Writer) error {
+	n := uint32(len(ba.values))
+
+	log.Printf("Writing bloom filter with n = %v, p = %v", n, ba.p)
+
+	f := bloom.Initialize(n, ba.p)
+
+	for _, v := range ba.values {
+		// Assuming UTF8 encoding
+		f.Add([]byte(v))
+	}
+
+	return f.Write(writer)
+}
+
+func (ba *BloomPageAggregator) Reset() {
+	ba.initialize()
 }
 
 // to be implemented

--- a/v1/paging_test.go
+++ b/v1/paging_test.go
@@ -1,0 +1,72 @@
+package gotie
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/DCSO/bloom"
+)
+
+func TestBloomPageAggregator(t *testing.T) {
+	iocsBuf, err := ioutil.TempFile("", "gotie-iocs")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(iocsBuf.Name())
+	bloomBuf, err := ioutil.TempFile("", "gotie-iocs")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(bloomBuf.Name())
+
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", 0, iocsBuf)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if _, err = iocsBuf.Seek(0, 0); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	agg := NewBloomPageAggregator(0.01)
+	agg.AddPage(iocsBuf)
+	agg.Finish(bloomBuf)
+
+	if _, err = iocsBuf.Seek(0, 0); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	jsonchan, err := GetIOCJSONInChan(iocsBuf)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	res, err := IOCChanCollect(jsonchan)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if len(res.Iocs) == 0 {
+		t.Logf("ERROR: JSON input channel yielded no results")
+		t.FailNow()
+	}
+
+	if _, err = bloomBuf.Seek(0, 0); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	filter, err := bloom.LoadFromReader(bloomBuf, false)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	n := 0
+	for _, ioc := range res.Iocs {
+		if !filter.Check([]byte(ioc.Value)) {
+			n++
+		}
+	}
+
+	if n != 0 {
+		t.Errorf("expected no negatives but got %v", n)
+	}
+}


### PR DESCRIPTION
On the command line one can specify `-f bloom`, p is by default `0.001` but can be changed e.g. with `--bloom-p 0.0001`. Example: `gotie -d iocs -f bloom > foo.bloom`