### PR TITLE
add support for Bloom filter v2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,6 +63,7 @@ Build a Bloom filter with capacity of 2000 entries and a false-positive probabil
 ```bash
 gotie iocs -f bloom --bloom-p 0.0001 --bloom-n 2000 --created-since $(date +%F) > test.bloom
 ```
+The default Bloom filter format (`bloom`) is TIE's 64-bit Bloom filter (v2). Gotie also supports the old Bloom filter format (v1) by specifying `bloomv1`.
 
 Perform a check with the bloom CLI tool:
 ```bash

--- a/v1/paging_test.go
+++ b/v1/paging_test.go
@@ -24,13 +24,13 @@ func TestBloomPageAggregator(t *testing.T) {
 	}
 	defer os.Remove(bloomBuf.Name())
 
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "json", iocsBuf)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2017-1-1", "json", iocsBuf)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 
 	tmp := bytes.NewBufferString("")
-	err = WriteIOCs("google", "domainname", "&first_seen_since=2015-1-1", "bloom", tmp)
+	err = WriteIOCs("google", "domainname", "&first_seen_since=2017-1-1", "bloom", tmp)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/v1/request.go
+++ b/v1/request.go
@@ -23,7 +23,9 @@ type MimeType string
 func NewMimeType(outputFormat string) (t MimeType, err error) {
 	switch outputFormat {
 	case "bloom":
-		return BLOOM, nil
+		return BLOOMv2, nil
+	case "bloomv1":
+		return BLOOMv1, nil
 	case "csv":
 		return CSV, nil
 	case "json":
@@ -37,7 +39,9 @@ func NewMimeType(outputFormat string) (t MimeType, err error) {
 
 func (t MimeType) Aggregator() PageContentAggregator {
 	switch t {
-	case BLOOM:
+	case BLOOMv1:
+		return &BloomPageAggregator{}
+	case BLOOMv2:
 		return &BloomPageAggregator{}
 	case CSV:
 		return &PaginatedRawPageAggregator{}
@@ -55,10 +59,11 @@ func (t MimeType) String() string {
 }
 
 const (
-	JSON  MimeType = "application/json"
-	CSV   MimeType = "text/csv"
-	BLOOM MimeType = "application/bloom"
-	STIX  MimeType = "text/xml"
+	JSON    MimeType = "application/json"
+	CSV     MimeType = "text/csv"
+	BLOOMv1 MimeType = "application/bloom"
+	BLOOMv2 MimeType = "application/bloom-v2"
+	STIX    MimeType = "text/xml"
 )
 
 type Request interface {


### PR DESCRIPTION
This PR adds support for the new 64-bit Bloom filter now available in the TIE. It will be used as the default format for the `-f bloom` parameter, unless `-f bloomv1` is used, which produces the old format.