### PR TITLE
make TIE API URL configurable

### DIFF
--- a/cmd/gotie/main.go
+++ b/cmd/gotie/main.go
@@ -150,9 +150,11 @@ func buildArgs(params Params, typestr string, debug bool) string {
 }
 
 type Options struct {
-	ConfPath string        `goptions:"-c,--conf,description='Set non default config path'"`
-	Debug    bool          `goptions:"-d,--debug,description='Print debug messages'"`
-	Help     goptions.Help `goptions:"-h, --help, description='Show this help'"`
+	ConfPath    string        `goptions:"-c,--conf,description='Set non default config path'"`
+	TieAPI      string        `goptions:"--tie-api,description='TIE API endpoint'"`
+	PingbackAPI string        `goptions:"--tie-pingback-api,description='TIE Pingback API endpoint'"`
+	Debug       bool          `goptions:"-d,--debug,description='Print debug messages'"`
+	Help        goptions.Help `goptions:"-h, --help, description='Show this help'"`
 
 	goptions.Verbs
 	IOCS     IOCSParams     `goptions:"iocs"`
@@ -163,7 +165,9 @@ type Options struct {
 func main() {
 	var err error
 	options := Options{
-		ConfPath: getDefaultConfPath(),
+		ConfPath:    getDefaultConfPath(),
+		TieAPI:      "https://tie.dcso.de/api/v1/",
+		PingbackAPI: "https://tie.dcso.de/api/v1/submit",
 		IOCS: IOCSParams{
 			Format:           "csv",
 			N:                "100000",
@@ -197,6 +201,9 @@ func main() {
 		panic(err)
 	}
 	gotie.AuthToken = CONF.TieToken
+
+	gotie.APIURL = options.TieAPI
+	gotie.PingbackURL = options.PingbackAPI
 
 	if options.Verbs == "iocs" {
 		var s int64

--- a/v1/functions.go
+++ b/v1/functions.go
@@ -32,8 +32,8 @@ var (
 	// AuthToken can be generated in the TIE webinterface and is used for authentication
 	AuthToken string
 
-	apiURL      = "https://tie.dcso.de/api/v1/"
-	pingbackURL = "https://tie.dcso.de/api/v1/submit/"
+	APIURL      = "https://tie.dcso.de/api/v1/"
+	PingbackURL = "https://tie.dcso.de/api/v1/submit/"
 	client      = http.Client{}
 )
 
@@ -166,7 +166,7 @@ func PingBackCall(dataType string, value string, token string) error {
 	form.Add("value", value)
 	form.Add("seen", currentDate)
 
-	req, err := http.NewRequest("POST", pingbackURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequest("POST", PingbackURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func PingBackCall(dataType string, value string, token string) error {
 	defer resp.Body.Close()
 
 	if Debug {
-		log.Println("Tried URL:" + apiURL + "submit")
+		log.Println("Tried URL:" + APIURL + "submit")
 		log.Println("Requested body data:", form.Encode())
 	}
 

--- a/v1/request.go
+++ b/v1/request.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tent/http-link-go"
+	link "github.com/tent/http-link-go"
 )
 
 type MimeType string
@@ -80,7 +80,7 @@ type FeedRequest struct {
 }
 
 func (r *FeedRequest) Url() string {
-	return apiURL + "iocs/feed/" + r.FeedPeriod + "/" + strings.ToLower(r.DataType) +
+	return APIURL + "iocs/feed/" + r.FeedPeriod + "/" + strings.ToLower(r.DataType) +
 		"?limit=" + strconv.Itoa(IOCLimit) +
 		"&date_format=rfc3339" +
 		r.ExtraArgs
@@ -96,7 +96,7 @@ type IOCRequest struct {
 }
 
 func (r *IOCRequest) Url() string {
-	return apiURL +
+	return APIURL +
 		"iocs?data_type=" + strings.ToLower(r.DataType) +
 		"&ivalue=" + r.Query +
 		"&limit=" + strconv.Itoa(IOCLimit) +


### PR DESCRIPTION
This PR adds the CLI parameters `--tie-api` and `--tie-pingback-api` to configure the API endpoint URLs to use. This allows to evaluate different backend implementations.